### PR TITLE
Fixed timeOfDayChanged event sending wrong time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2023-08-19
+
+### Fixed
+
+- When Applying a new Time, the correct new time is being sent by the event instead of the old time.
+
 ## [1.0.0] - 2023-07-27
 
 ### Added

--- a/Runtime/Scripts/SunTime.cs
+++ b/Runtime/Scripts/SunTime.cs
@@ -193,11 +193,10 @@ namespace Netherlands3D.Sun
             var newTime = new DateTime(year, month, day, hour, minutes, seconds, dateTimeKind);
             if (newTime != time)
             {
-                timeOfDayChanged.Invoke(time);
+                time = newTime;
+                SetPosition();
+                timeOfDayChanged.Invoke(newTime);
             }
-
-            time = newTime;
-            SetPosition();
         }
 
         private void DetermineCurrentLocationFromOrigin()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.sun",
   "displayName": "Netherlands3D - Sun, Time of Day and Shadows",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "unity": "2022.2",
   "description": "",
   "type": "library",


### PR DESCRIPTION
 When Applying a new Time, the correct new time is being sent by the event instead of the old time.