### PR TITLE
Feature/time zone support 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2023-03-14
+
+### Added
+- Added Support for time zones and local time. To convert the time to UTC for proper calculation of the sun position. This replaces the built in ToUniversalTime function since it did not work correctly in WebGL. The time zones of the GeoTimeZone package are read form a local table of information which is valid for historical data from 1916 to 2019, and has assumed correct data from 2019 until 2037 (this period can possibli no longer be valid if a country changes its time zone or DST).
+
 ## [1.3.0] - 2023-09-03
 
 ### Added

--- a/Runtime/Scripts/SunPosition.cs
+++ b/Runtime/Scripts/SunPosition.cs
@@ -3,6 +3,7 @@
 * http://guideving.blogspot.co.uk/2010/08/sun-position-in-c.html
 */
 using System;
+using GeoTimeZone;
 
 namespace Netherlands3D.Sun
 {
@@ -28,9 +29,9 @@ namespace Netherlands3D.Sun
         public static void CalculateSunPosition(
             DateTime dateTime, double latitude, double longitude, out double outAzimuth, out double outAltitude)
         {
-            // Convert to UTC  
-            dateTime = dateTime.ToUniversalTime();
-
+            var timeZoneId = TimeZoneLookup.GetTimeZone(latitude, longitude).Result; //get the local time zone
+            dateTime = TimeZoneConverter.ConvertToUTC(dateTime, timeZoneId); //convert the time to UTC
+            
             // Number of days from J2000.0.  
             double julianDate = 367 * dateTime.Year -
                 (int)((7.0 / 4.0) * (dateTime.Year +

--- a/Runtime/Scripts/eu.netherlands3d.sun.Runtime.asmdef
+++ b/Runtime/Scripts/eu.netherlands3d.sun.Runtime.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "Netherlands3D.Sun",
     "references": [
         "GUID:19c45768ddcd67943afbf0cb4e4ff0b3",
+        "GUID:dc9cb57b6d4af4e78826d53f28a1278f",
         "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "displayName": "Netherlands3D - Sun, Time of Day and Shadows",
   "version": "1.3.0",
   "unity": "2022.2",
-  "description": "",
   "type": "library",
   "keywords": [
     "sun",
@@ -21,6 +20,7 @@
     "url": "https://netherlands3d.eu"
   },
   "dependencies": {
-    "eu.netherlands3d.coordinates": "1.1.0"
+    "eu.netherlands3d.coordinates": "1.1.0",
+    "eu.netherlands3d.geotimezone": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "eu.netherlands3d.coordinates": "1.1.0",
-    "eu.netherlands3d.geotimezone": "1.0.0"
+    "eu.netherlands3d.geotimezone": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eu.netherlands3d.sun",
   "displayName": "Netherlands3D - Sun, Time of Day and Shadows",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "unity": "2022.2",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
Added Support for time zones and local time. To convert the time to UTC for proper calculation of the sun position. This replaces the built in ToUniversalTime function since it did not work correctly in WebGL. The time zones of the GeoTimeZone package are read form a local table of information which is valid for historical data from 1916 to 2019, and has assumed correct data from 2019 until 2037 (this period can possibli no longer be valid if a country changes its time zone or DST).